### PR TITLE
🔧 fix loadScripts context

### DIFF
--- a/packages/core/browser-vm/src/Context.js
+++ b/packages/core/browser-vm/src/Context.js
@@ -46,7 +46,7 @@ class Context {
           }
         }
       }//@ sourceMappingURL=${url}`)
-    resolver()({...this})
+    resolver().call(this.window, {...this})
   }
 
   updateBody(dom) {


### PR DESCRIPTION
对于使用 `context.loadScripts` 去加载一些 UMD 打包的库，会造成 this 的指向不是 window。比如：https://cdn.jsdelivr.net/npm/react@16.14.0/umd/react.development.js

```js
(function (global, factory) {
  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
  typeof define === 'function' && define.amd ? define(['exports'], factory) :
  (global = global || self, factory(global.React = {}));
}(this, (function (exports) { // ! 此处 this 指向错误
  ...
})));
```