### PR TITLE
🔧 fix VMContext types

### DIFF
--- a/packages/core/browser-vm/index.d.ts
+++ b/packages/core/browser-vm/index.d.ts
@@ -5,6 +5,8 @@ export interface VMContext {
   history: History;
   location: Location;
   baseFrame?: HTMLFrameElement;
+  body: HTMLBodyElement;
+  loadScripts: (url: string) => Promise<void>;
   updateBody?: (body: Element) => void;
 }
 


### PR DESCRIPTION
修正 VMContext 的类型定义，补充：

```ts
  body: HTMLBodyElement;
  loadScripts: (url: string) => Promise<void>;
```