### PR TITLE
fix: SubApp/Angular custom-webpack version error

### DIFF
--- a/example/SubApp/Angular/angular.json
+++ b/example/SubApp/Angular/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": "62842641-77dd-4ca9-92f2-e3ef74882a57"
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
@@ -58,7 +61,7 @@
           }
         },
         "serve": {
-          "builder": "@angular-builders/dev-server:generic",
+          "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
             "browserTarget": "angular.io-example:build"
           },

--- a/example/SubApp/Angular/package.json
+++ b/example/SubApp/Angular/package.json
@@ -5,14 +5,14 @@
   "dependencies": {
     "@alicloud/console-os-ng-builder": "^1.2.3",
     "@alicloud/console-os-ng-portal": "^1.0.0-next.11",
-    "@angular/animations": "8.2.14",
-    "@angular/common": "8.2.14",
-    "@angular/compiler": "8.2.14",
-    "@angular/core": "8.2.14",
-    "@angular/forms": "8.2.14",
-    "@angular/platform-browser": "8.2.14",
-    "@angular/platform-browser-dynamic": "8.2.14",
-    "@angular/router": "8.2.14",
+    "@angular/animations": "~8.2.3",
+    "@angular/common": "~8.2.4",
+    "@angular/compiler": "~8.2.4",
+    "@angular/core": "~8.2.4",
+    "@angular/forms": "~8.2.4",
+    "@angular/platform-browser": "~8.2.4",
+    "@angular/platform-browser-dynamic": "~8.2.4",
+    "@angular/router": "~8.2.4",
     "@babel/runtime": "^7.7.4",
     "angular-in-memory-web-api": "0.8.0",
     "core-js": "2.6.10",
@@ -35,12 +35,11 @@
     "serve:single-spa": "ng serve --disable-host-check --port 4200 --deploy-url http://localhost:4200/ --live-reload false"
   },
   "devDependencies": {
-    "@angular-builders/custom-webpack": "^7.0.0",
-    "@angular-builders/dev-server": "^7.3.1",
-    "@angular-devkit/build-angular": "~0.13.0",
-    "@angular/cli": "^7.0.2",
-    "@angular/compiler-cli": "^7.0.0",
-    "@angular/language-service": "^7.0.0",
+    "@angular-builders/custom-webpack": "~8.2.0",
+    "@angular-devkit/build-angular": "~0.803.28",
+    "@angular/cli": "~8.2.2",
+    "@angular/compiler-cli": "~8.2.4",
+    "@angular/language-service": "~8.2.4",
     "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",
@@ -55,7 +54,8 @@
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
-    "typescript": "~3.1.1",
-    "webpack-assets-manifest": "^3.1.1"
+    "typescript": "~3.4.1",
+    "webpack-assets-manifest": "^3.1.1",
+    "webpack-chain": "^6.5.1"
   }
 }


### PR DESCRIPTION
修复angular 示例运行报错的问题。
原例子中@angular-builders/dev-server 在8系列已经抛弃，使用@angular-builders/custom-webpack:dev-server替代。
并需要保证angualr核心库版本尽量保持一致，故升级到8系列，并升级typescript和补充其他依赖。